### PR TITLE
Don't try to close the db if it was never opened.

### DIFF
--- a/index.js
+++ b/index.js
@@ -139,7 +139,9 @@ module.exports = function(app) {
     clearInterval(submitProcess);
     clearInterval(monitoringProcess);
     clearInterval(statusProcess);
-    db.close();
+    if (db) {
+      db.close();
+    }
   };
 
   plugin.schema = {


### PR DESCRIPTION
This can happen when initially configuring the plugin and cause an inability
to save the initial configuration.

As per https://github.com/SignalK/signalk-server/blob/9dbb3242a7806a663ff61074e89191e9a6a18f24/SERVERPLUGINS.md?plain=1#L23
`stop()` is called when the configuration is saved, so if the plugin hasn't been started successfully yet that
is a problem.