### PR TITLE
Add DSC (Digital Selective Calling) parsing and forwarding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 .DS_Store
 package-lock.json
+CLAUDE.md
+docs/
+
 # Logs
 logs
 *.log

--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ For additional information, visit:
 - [Community Forums](https://community.saillogger.com/)
 - [Video Tutorials and Demos](https://youtube.com/@Saillogger)
 
+## DSC Alerts
+The plugin parses DSC (VHF Digital Selective Calling) calls from NMEA 0183 (`$CDDSC`/`$CDDSE`) and NMEA 2000 (PGN 129808) and forwards them to Saillogger immediately, so distress, urgency, and safety traffic in your area is captured as it is received.
+
 ## Feedback
 We welcome feature requests and bug reports on our [community forum](https://community.saillogger.com).
 

--- a/index.js
+++ b/index.js
@@ -19,11 +19,16 @@ const SUBMIT_INTERVAL = 1             // Submit to server every N minutes
 const AIS_SUBMISSION_INTERVAL = 5     // Submit AIS data every N minutes
 const SEND_METADATA_INTERVAL = 1      // Submit to API every N hours
 const API_BASE = 'https://saillogger.com/api/v1/collector'
+const DSC_PGN = 129808                // NMEA 2000 DSC Call Information
+const DSC_MAX_ATTEMPTS = 3            // DSC alert delivery attempts before dropping
+const DSC_RETRY_INTERVAL = 15         // Seconds between DSC delivery attempts
+const DSE_PAIR_WINDOW = 2             // Minutes to pair a DSE refinement with its DSC call
 
 const fs = require('fs')
 const filePath = require('path')
 const request = require('request')
 const { BufferStore, ConfigStore } = require('./lib/storage')
+const { parseDsc, parseDse, refinePosition, normalizePgn129808 } = require('./lib/dsc')
 const { machineId, machineIdSync } = require('node-machine-id');
 const package = require('./package.json');
 const userAgent = `Saillogger plugin v${package.version}`;
@@ -59,6 +64,10 @@ module.exports = function(app) {
   var previousCOGs = [];
   var deviceSerialNumber;
   var aisTarget = {};
+  var dscStarted = false;
+  var dscParsersRegistered = false;
+  var recentDscCalls = [];
+  var dscRetryTimers = [];
   const selfMmsi = app.getSelfPath('mmsi');
 
   plugin.id = "signalk-saillogger";
@@ -75,6 +84,11 @@ module.exports = function(app) {
     clearInterval(sendMetadataProcess);
     clearInterval(aisSubmissionProcess);
     clearInterval(submitDataProcess);
+    dscStarted = false;
+    dscRetryTimers.forEach(clearTimeout);
+    dscRetryTimers = [];
+    recentDscCalls = [];
+    app.removeListener('N2KAnalyzerOut', handleDscPgn);
   };
 
   plugin.schema = {
@@ -148,6 +162,23 @@ module.exports = function(app) {
     app.subscriptionmanager.subscribe(subscription, unsubscribes, function() {
       app.error('Subscription error');
     }, data => processDelta(data));
+
+    // DSC calls are event-driven and safety-critical: parse and forward each
+    // one immediately rather than buffering. Always on; both NMEA 0183
+    // ($CDDSC/$CDDSE) and NMEA 2000 (PGN 129808) are handled.
+    dscStarted = true;
+    // SignalK has no API to unregister an nmea0183sentenceParser, so register
+    // the 0183 parsers only once per process lifetime; a restart would otherwise
+    // stack duplicate copies that each forward the same call.
+    if (!dscParsersRegistered) {
+      app.emitPropertyValue('nmea0183sentenceParser', { sentence: 'DSC', parser: handleDscSentence });
+      app.emitPropertyValue('nmea0183sentenceParser', { sentence: 'DSE', parser: handleDseSentence });
+      dscParsersRegistered = true;
+    }
+    // Remove-before-add keeps the N2K listener idempotent even if the server
+    // ever calls start() again without an intervening stop().
+    app.removeListener('N2KAnalyzerOut', handleDscPgn);
+    app.on('N2KAnalyzerOut', handleDscPgn);
 
     updatePluginStatus();
     getConfiguration();
@@ -665,6 +696,174 @@ module.exports = function(app) {
         app.debug('Submission of AIS data failed');
       }
     });
+  }
+
+  function ownPositionNow() {
+    let pos = app.getSelfPath('navigation.position');
+    if (pos && pos.value && typeof pos.value.latitude === 'number') {
+      return { latitude: pos.value.latitude, longitude: pos.value.longitude };
+    }
+    return null;
+  }
+
+  function sendDscEvent(event, attempt, targetUuid) {
+    attempt = attempt || 1;
+    // Bind the uuid from when the call arrived, so a retry that fires after a
+    // restart with a different Collector ID still posts to the original boat.
+    targetUuid = targetUuid || uuid;
+    let httpOptions = {
+      uri: API_BASE + '/dsc/' + targetUuid + '/push',
+      method: 'POST',
+      json: JSON.stringify(event),
+      headers: {
+        'User-Agent': userAgent,
+      },
+      timeout: 30000
+    };
+    request(httpOptions, function (error, response, body) {
+      let status = response ? response.statusCode : null;
+      if (!error && status >= 200 && status < 300) {
+        // 2xx = accepted, including a server-deduped repeat.
+        app.debug(`DSC ${event.category} call from MMSI ${event.mmsi || 'unknown'} submitted (HTTP-${status})`);
+      } else if (!error && status >= 300 && status < 500) {
+        // Permanent: a 4xx client error (400 bad body, 404 unknown collector id)
+        // or a 3xx redirect a POST will not follow. Retrying will not help.
+        app.debug(`DSC submission not accepted (HTTP-${status}), dropping`);
+      } else if (attempt < DSC_MAX_ATTEMPTS) {
+        // Transient failure (5xx, network/timeout, or an undiagnosable response):
+        // retry, then drop. Skip scheduling if the plugin has since stopped so a
+        // late callback cannot leak a timer past stop() or re-send under a new uuid.
+        if (!dscStarted) return;
+        app.debug(`DSC submission failed (${status ? `HTTP-${status}` : error}, attempt ${attempt}/${DSC_MAX_ATTEMPTS}), retrying in ${DSC_RETRY_INTERVAL}s`);
+        let timer = setTimeout(function () {
+          dscRetryTimers = dscRetryTimers.filter(function (t) { return t !== timer; });
+          if (dscStarted) sendDscEvent(event, attempt + 1, targetUuid);
+        }, DSC_RETRY_INTERVAL * 1000);
+        dscRetryTimers.push(timer);
+      } else {
+        app.debug(`DSC submission failed after ${DSC_MAX_ATTEMPTS} attempts, dropping`);
+      }
+    });
+  }
+
+  function forwardDscCall(parsed, meta) {
+    let event = Object.assign({
+      receivedAt: meta.receivedAt || new Date().toISOString(),
+      source: meta.source,
+      raw: meta.raw
+    }, parsed);
+    let ownPosition = ownPositionNow();
+    if (ownPosition) {
+      event.ownPosition = ownPosition;
+    }
+    // selfMmsi comes straight from the data model (may be a number or an
+    // unpadded string); event.mmsi is always a 9-digit string, so compare in
+    // a normalized form.
+    if (event.mmsi && selfMmsi != null &&
+        event.mmsi === String(selfMmsi).padStart(9, '0')) {
+      event.self = true;
+    }
+    sendDscEvent(event);
+    return event;
+  }
+
+  // Keep a recently forwarded DSC call so a following $--DSE sentence can refine
+  // its (whole-minute) position. DSC traffic is rare, so a short in-memory list
+  // pruned by the pairing window is enough.
+  function recordDscForDse(event) {
+    recentDscCalls.push({ event: event, ts: Date.now() });
+    let cutoff = Date.now() - DSE_PAIR_WINDOW * 60 * 1000;
+    recentDscCalls = recentDscCalls.filter(function (c) { return c.ts >= cutoff; });
+  }
+
+  function findRecentDscForDse(mmsi) {
+    let cutoff = Date.now() - DSE_PAIR_WINDOW * 60 * 1000;
+    for (let i = recentDscCalls.length - 1; i >= 0; i--) {
+      if (recentDscCalls[i].ts < cutoff) break;
+      if (recentDscCalls[i].event.mmsi === mmsi) {
+        return recentDscCalls[i].event;
+      }
+    }
+    return null;
+  }
+
+  function handleDscSentence(input) {
+    if (!dscStarted) return null;
+    try {
+      let parsed = parseDsc(input.parts);
+      if (!parsed) return null;
+      if (parsed.position) {
+        parsed.positionResolution = 'minute';
+      }
+      let event = forwardDscCall(parsed, {
+        source: 'nmea0183',
+        raw: input.sentence,
+        receivedAt: input.tags && input.tags.timestamp
+      });
+      if (event.mmsi && event.position && event.positionResolution === 'minute') {
+        recordDscForDse(event);
+      }
+    } catch (err) {
+      app.debug(`DSC parse failed: ${err.message}`);
+    }
+    // Forward-only: consume the sentence, emit no Signal K delta.
+    return null;
+  }
+
+  function handleDseSentence(input) {
+    if (!dscStarted) return null;
+    try {
+      let ext = parseDse(input.parts);
+      if (!ext) return null;
+      let target = findRecentDscForDse(ext.mmsi);
+      if (!target) return null;
+      let refined = refinePosition(target.position, ext);
+      let event = Object.assign({}, target, {
+        position: refined,
+        positionResolution: 'enhanced',
+        positionRefined: true,
+        raw: input.sentence,
+        receivedAt: new Date().toISOString()
+      });
+      // Re-sample own position so the observer annotation matches when the
+      // refinement is forwarded, not when the original DSC call arrived.
+      let ownPosition = ownPositionNow();
+      if (ownPosition) {
+        event.ownPosition = ownPosition;
+      } else {
+        delete event.ownPosition;
+      }
+      sendDscEvent(event);
+    } catch (err) {
+      app.debug(`DSE parse failed: ${err.message}`);
+    }
+    return null;
+  }
+
+  function handleDscPgn(pgnData) {
+    if (!dscStarted || !pgnData || pgnData.pgn !== DSC_PGN) return;
+    try {
+      // Dump the raw PGN field shape so the actual canboatjs field naming on
+      // this server can be analyzed (camelCase vs. canboat's spaced form).
+      app.debug(`DSC PGN 129808 received; raw fields: ${JSON.stringify(pgnData.fields)}`);
+      let parsed = normalizePgn129808(pgnData);
+      let fieldCount = pgnData.fields ? Object.keys(pgnData.fields).length : 0;
+      if (parsed.category === 'unknown' && !parsed.mmsi && !parsed.position) {
+        // Nothing usable decoded (e.g. a field-key mismatch): log the shape for
+        // analysis but do not forward noise to the backend.
+        if (fieldCount) {
+          app.debug(`DSC PGN 129808 did not decode despite ${fieldCount} field(s); ` +
+            `unrecognized field keys: ${Object.keys(pgnData.fields).join(', ')}`);
+        }
+        return;
+      }
+      forwardDscCall(parsed, {
+        source: 'n2k',
+        raw: pgnData.fields
+      });
+    } catch (err) {
+      app.debug(`PGN 129808 handling failed: ${err.message}`);
+    }
   }
 
   function getMonitoringData(configuration) {

--- a/lib/dsc.js
+++ b/lib/dsc.js
@@ -1,0 +1,364 @@
+/*
+ * Copyright 2024 Saillogger LLC <info@saillogger.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * DSC (VHF Digital Selective Calling) parsers. The NMEA 0183 ($--DSC / $--DSE)
+ * and NMEA 2000 (PGN 129808) decoding is adapted from signalk-dsc
+ * (https://github.com/sailingnaturali/signalk-dsc), Copyright (c) 2026
+ * Bryan Clark, released under the MIT License.
+ *
+ * Each parser returns a canonical, transport-independent DSC event:
+ *   { format, category, mmsi, deviceBeacon?, natureOfDistress?, relay?,
+ *     distressedMmsi?, position?: {latitude, longitude}, utcTime?,
+ *     workingChannel?, acknowledgement?, expansion? }
+ * Tolerant by design: anything that cannot be interpreted stays undefined.
+ */
+
+'use strict';
+
+const FORMATS = {
+  '02': 'area',
+  '12': 'distressAlert',
+  '14': 'group',
+  '16': 'allShips',
+  '20': 'individual',
+  '23': 'autoService',
+};
+
+const CATEGORIES = {
+  '00': 'routine',
+  '08': 'safety',
+  '10': 'urgency',
+  '12': 'distress',
+};
+
+const NATURES = {
+  '00': 'fire',
+  '01': 'flooding',
+  '02': 'collision',
+  '03': 'grounding',
+  '04': 'listing',
+  '05': 'sinking',
+  '06': 'adrift',
+  '07': 'undesignated',
+  '08': 'abandon',
+  '09': 'piracy',
+  '10': 'mob',
+  '12': 'epirb',
+};
+
+// Telecommand 21 on a non-distress call = "ship position": field 5 is a position.
+const TELECOMMAND_SHIP_POSITION = '21';
+
+// AIS device-beacon MMSI prefixes (ITU 97x): a SART / MOB / EPIRB beacon can
+// send a DSC distress directly. The tag lets the backend correlate it with the
+// matching AIS target.
+const DEVICE_BEACONS = { '970': 'sart', '972': 'mob', '974': 'epirb' };
+
+function deviceBeaconFor(mmsi) {
+  if (typeof mmsi !== 'string') return undefined;
+  return DEVICE_BEACONS[mmsi.substring(0, 3)];
+}
+
+// Resolve a nature-of-distress code to its name. The code arrives over the air
+// unsanitised, so only a clean 1-2 digit numeric code reaches the lookup; a key
+// like "__proto__" would otherwise resolve to Object.prototype. Anything else
+// collapses to a safe constant.
+function parseNature(raw) {
+  return /^\d{1,2}$/.test(raw) ? NATURES[raw] || `code-${raw}` : 'undesignated';
+}
+
+function field(parts, i) {
+  const v = parts[i];
+  return typeof v === 'string' ? v.trim() : '';
+}
+
+// DSC sentences carry the MMSI with a trailing zero (MMSI * 10).
+function parseMmsi(raw) {
+  if (typeof raw !== 'string') return undefined;
+  const digits = raw.trim();
+  if (!/^\d{9,10}$/.test(digits)) return undefined;
+  return digits.length === 10 ? digits.substring(0, 9) : digits;
+}
+
+function parsePosition(raw) {
+  if (typeof raw !== 'string' || !/^\d{10}$/.test(raw)) return undefined;
+  if (raw === '9999999999') return undefined; // "position not available"
+  const quadrant = Number(raw[0]); // 0 NE, 1 NW, 2 SE, 3 SW
+  if (quadrant > 3) return undefined;
+  const latMin = Number(raw.substring(3, 5));
+  const lonMin = Number(raw.substring(8, 10));
+  if (latMin >= 60 || lonMin >= 60) return undefined; // garbled minute field
+  let latitude = Number(raw.substring(1, 3)) + latMin / 60;
+  let longitude = Number(raw.substring(5, 8)) + lonMin / 60;
+  // The field arrives over the air unvalidated; an out-of-range value cannot be
+  // interpreted as a position, so it stays undefined like the "unavailable" code.
+  if (latitude > 90 || longitude > 180) return undefined;
+  if (quadrant === 1 || quadrant === 3) longitude = -longitude;
+  if (quadrant === 2 || quadrant === 3) latitude = -latitude;
+  return { latitude, longitude };
+}
+
+function parseUtcTime(raw) {
+  if (typeof raw !== 'string' || !/^\d{4}$/.test(raw.trim())) return undefined;
+  const t = raw.trim();
+  if (t === '8888') return undefined; // "time not available"
+  return `${t.substring(0, 2)}:${t.substring(2, 4)}`;
+}
+
+// VHF channel plausibility: 1-99 (international) or the 4-digit simplex forms.
+function parseChannel(raw) {
+  if (typeof raw !== 'string' || !/^\d{1,6}$/.test(raw.trim())) return undefined;
+  const t = raw.trim();
+  // A leading 9 on a 6-digit value marks "channel number follows" (900072 = 72).
+  const digits = /^9\d{5}$/.test(t) ? t.slice(1) : t;
+  const n = Number(digits);
+  if (!Number.isInteger(n)) return undefined;
+  if ((n >= 1 && n <= 99) || (n >= 1001 && n <= 1099) || (n >= 2001 && n <= 2099)) {
+    return String(n);
+  }
+  return undefined;
+}
+
+/**
+ * Parse the comma-split fields of a $--DSC sentence (id and checksum already
+ * stripped). Returns null only when there is nothing usable at all.
+ *
+ *        0  1          2  3  4  5          6    7 8 9 10
+ * $--DSC,XX,XXXXXXXXXX,XX,XX,XX,XXXXXXXXXX,XXXX,,,A,C*hh
+ */
+function parseDsc(parts) {
+  if (!Array.isArray(parts) || parts.length < 2) return null;
+
+  const formatCode = field(parts, 0);
+  let categoryCode = field(parts, 2);
+  // Some radios omit the category on distress alerts; it is implied by 112.
+  if (!categoryCode && formatCode === '12') categoryCode = '12';
+
+  const event = {
+    format: FORMATS[formatCode] || 'unknown',
+    category: CATEGORIES[categoryCode] || 'unknown',
+    mmsi: parseMmsi(parts[1]),
+  };
+
+  const beacon = deviceBeaconFor(event.mmsi);
+  if (beacon) event.deviceBeacon = beacon;
+
+  const distress = event.category === 'distress';
+  if (distress) {
+    // A distress relay (all-ships / area / individual format) reports the
+    // casualty in field 7 and the nature in field 8; a first-party alert
+    // (distressAlert format) carries the nature in field 3, and field 7 has
+    // no casualty meaning (the alerting vessel in field 1 is the casualty).
+    if (event.format !== 'distressAlert') {
+      event.relay = true;
+      event.natureOfDistress = parseNature(field(parts, 8));
+      event.distressedMmsi = parseMmsi(parts[7]);
+    } else {
+      event.natureOfDistress = parseNature(field(parts, 3));
+    }
+  }
+
+  if (distress || field(parts, 3) === TELECOMMAND_SHIP_POSITION) {
+    event.position = parsePosition(field(parts, 5));
+    event.utcTime = parseUtcTime(field(parts, 6));
+  } else {
+    const channel = parseChannel(field(parts, 5));
+    if (channel) event.workingChannel = channel;
+  }
+
+  const ack = field(parts, 9);
+  if (ack) event.acknowledgement = ack;
+  event.expansion = field(parts, 10) === 'E';
+
+  return event;
+}
+
+const DSE_CODE_ENHANCED_POSITION = '00';
+
+/**
+ * Parse a $--DSE sentence (the expansion that can follow a $--DSC, refining its
+ * position from whole minutes to ten-thousandths of a minute). Returns
+ * { mmsi, latMinuteFraction, lonMinuteFraction } for single-sentence position
+ * extensions, else null.
+ *
+ *        0 1 2 3          4  5
+ * $--DSE,t,n,A,XXXXXXXXXX,00,llllyyyy*hh
+ */
+function parseDse(parts) {
+  if (!Array.isArray(parts) || parts.length < 6) return null;
+  // Multi-sentence groups are vanishingly rare on Class-D gear; skip them.
+  if (field(parts, 0) !== '1' || field(parts, 1) !== '1') return null;
+
+  const mmsi = parseMmsi(parts[3]);
+  if (!mmsi) return null;
+
+  for (let i = 4; i + 1 < parts.length; i += 2) {
+    const code = field(parts, i);
+    const data = field(parts, i + 1);
+    if (code === DSE_CODE_ENHANCED_POSITION && /^\d{8}$/.test(data)) {
+      return {
+        mmsi,
+        latMinuteFraction: Number(data.substring(0, 4)) / 10000,
+        lonMinuteFraction: Number(data.substring(4, 8)) / 10000,
+      };
+    }
+  }
+  return null;
+}
+
+/**
+ * Apply a DSE extension to a DSC position. DSC truncates coordinates toward
+ * zero, so the fractional minutes always extend the magnitude (sign-preserving).
+ */
+function refinePosition(position, ext) {
+  const extend = (value, minuteFraction) => {
+    // Object.is guards negative zero: parsePosition yields -0 for a coordinate
+    // at exactly 0deg in a W/S quadrant, and -0 < 0 is false, which would flip
+    // the DSE-refined coordinate to the wrong hemisphere.
+    const sign = value < 0 || Object.is(value, -0) ? -1 : 1;
+    return sign * (Math.abs(value) + minuteFraction / 60);
+  };
+  return {
+    latitude: extend(position.latitude, ext.latMinuteFraction),
+    longitude: extend(position.longitude, ext.lonMinuteFraction),
+  };
+}
+
+/*
+ * NMEA 2000 PGN 129808 "DSC Call Information". canboatjs (useCamelCompat)
+ * resolves lookups to their names; the distress variant uses
+ * dscFormat/dscCategory/natureOfDistress, the general variant the *Symbol
+ * fields. When a lookup cannot be resolved the raw ITU symbol number (1xx)
+ * comes through instead, so both are handled.
+ */
+const N2K_FORMATS = new Map([
+  ['geographical area', 'area'],
+  ['distress', 'distressAlert'],
+  ['common interest', 'group'],
+  ['group call', 'group'],
+  ['all ships', 'allShips'],
+  ['individual stations', 'individual'],
+  ['individual station automatic', 'autoService'],
+  [102, 'area'], [112, 'distressAlert'], [114, 'group'],
+  [116, 'allShips'], [120, 'individual'], [123, 'autoService'],
+]);
+
+const N2K_CATEGORIES = new Map([
+  ['routine', 'routine'], ['safety', 'safety'],
+  ['urgency', 'urgency'], ['distress', 'distress'],
+  [100, 'routine'], [108, 'safety'], [110, 'urgency'], [112, 'distress'],
+]);
+
+const N2K_NATURES = new Map([
+  ['fire, explosion', 'fire'],
+  ['flooding', 'flooding'],
+  ['collision', 'collision'],
+  ['grounding', 'grounding'],
+  ['listing, in danger of capsizing', 'listing'],
+  ['sinking', 'sinking'],
+  ['disabled and adrift', 'adrift'],
+  ['undesignated distress', 'undesignated'],
+  ['abandoning ship', 'abandon'],
+  ['piracy/armed robbery attack', 'piracy'],
+  ['man overboard', 'mob'],
+  ['epirb emission', 'epirb'],
+  [0, 'fire'], [1, 'flooding'], [2, 'collision'], [3, 'grounding'],
+  [4, 'listing'], [5, 'sinking'], [6, 'adrift'], [7, 'undesignated'],
+  [8, 'abandon'], [9, 'piracy'], [10, 'mob'], [12, 'epirb'],
+]);
+
+function n2kLookup(map, value) {
+  if (value === undefined || value === null) return undefined;
+  if (typeof value === 'string') {
+    const hit = map.get(value.trim().toLowerCase());
+    if (hit) return hit;
+    const asNumber = Number(value);
+    return Number.isNaN(asNumber) ? undefined : map.get(asNumber);
+  }
+  return map.get(value);
+}
+
+function n2kMmsi(value) {
+  if (value === undefined || value === null || value === '') return undefined;
+  const digits = String(value).trim();
+  if (!/^\d{1,9}$/.test(digits) || Number(digits) === 0) return undefined;
+  return digits.padStart(9, '0');
+}
+
+function n2kTime(value) {
+  if (typeof value === 'string') {
+    const m = value.match(/^(\d{2}):(\d{2})/);
+    return m ? `${m[1]}:${m[2]}` : undefined;
+  }
+  if (typeof value === 'number' && value >= 0 && value < 86400) {
+    const h = String(Math.floor(value / 3600)).padStart(2, '0');
+    const min = String(Math.floor((value % 3600) / 60)).padStart(2, '0');
+    return `${h}:${min}`;
+  }
+  return undefined;
+}
+
+// canboatjs may key PGN fields either camelCased (dscFormat — useCamelCompat)
+// or in canboat's canonical spaced form (DSC Format), depending on its version
+// and config. Collapse both (and underscored variants) to a space/underscore-
+// stripped, lower-cased key so the normalizer reads the fields either way.
+function canonicalFields(fields) {
+  const map = {};
+  for (const key in fields) {
+    if (!Object.prototype.hasOwnProperty.call(fields, key)) continue;
+    const canon = key.replace(/[\s_]+/g, '').toLowerCase();
+    if (!(canon in map)) map[canon] = fields[key];
+  }
+  return map;
+}
+
+/** Normalize a canboatjs-parsed PGN 129808 object into a canonical DSC event. */
+function normalizePgn129808(pgnData) {
+  const f = canonicalFields((pgnData && pgnData.fields) || {});
+  const get = (...names) => {
+    for (const n of names) {
+      if (f[n] !== undefined && f[n] !== null) return f[n];
+    }
+    return undefined;
+  };
+
+  const event = {
+    format: n2kLookup(N2K_FORMATS, get('dscformat', 'dscformatsymbol')) || 'unknown',
+    category: n2kLookup(N2K_CATEGORIES, get('dsccategory', 'dsccategorysymbol')) || 'unknown',
+    mmsi: n2kMmsi(get('dscmessageaddress')),
+  };
+
+  const beacon = deviceBeaconFor(event.mmsi);
+  if (beacon) event.deviceBeacon = beacon;
+
+  if (event.category === 'distress') {
+    const nature = get('natureofdistress', '1sttelecommand');
+    event.natureOfDistress = n2kLookup(N2K_NATURES, nature) || 'undesignated';
+    if (event.format !== 'distressAlert') event.relay = true;
+  }
+
+  const lat = get('latitudeofvesselreported');
+  const lon = get('longitudeofvesselreported');
+  // Range-check like the 0183 parsePosition: an out-of-range value is a garbled
+  // or not-available decode, not a position.
+  if (typeof lat === 'number' && typeof lon === 'number' &&
+      Math.abs(lat) <= 90 && Math.abs(lon) <= 180) {
+    event.position = { latitude: lat, longitude: lon };
+  }
+
+  const time = n2kTime(get('timeofposition'));
+  if (time) event.utcTime = time;
+
+  const distressed = n2kMmsi(get('mmsiofshipindistress'));
+  if (distressed) event.distressedMmsi = distressed;
+
+  return event;
+}
+
+module.exports = { parseDsc, parseDse, refinePosition, normalizePgn129808 };

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "signalk-saillogger",
-  "version": "5.1.0",
+  "version": "5.2.0",
   "description": "Maintenance-free, fully automated logbook and remote boat monitoring solution",
   "main": "index.js",
   "signalk-plugin-enabled-by-default": true,
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node --test"
   },
   "keywords": [
     "signalk-node-server-plugin"

--- a/test/dsc.test.js
+++ b/test/dsc.test.js
@@ -1,0 +1,172 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert');
+
+const { parseDsc, parseDse, refinePosition, normalizePgn129808 } = require('../lib/dsc');
+
+// Fields as the NMEA 0183 parser delivers them: talker+sentence id and checksum
+// already stripped, so parts[0] is the DSC format specifier.
+
+test('parseDsc: first-party distress alert with position', () => {
+  const e = parseDsc(['12', '2442236000', '12', '02', '00', '0484700327', '1423', '', '', '', 'E']);
+  assert.equal(e.format, 'distressAlert');
+  assert.equal(e.category, 'distress');
+  assert.equal(e.mmsi, '244223600'); // trailing-zero (MMSI * 10) stripped
+  assert.equal(e.natureOfDistress, 'collision');
+  assert.ok(Math.abs(e.position.latitude - 48.7833333) < 1e-4);
+  assert.ok(Math.abs(e.position.longitude - 3.45) < 1e-4);
+  assert.equal(e.utcTime, '14:23');
+  assert.equal(e.expansion, true);
+  assert.equal(e.relay, undefined);
+});
+
+test('parseDsc: distress relay reports casualty in fields 7/8', () => {
+  const e = parseDsc(['16', '0023711000', '12', '', '', '0484700327', '1423', '2442236000', '05', '', '']);
+  assert.equal(e.format, 'allShips');
+  assert.equal(e.category, 'distress');
+  assert.equal(e.relay, true);
+  assert.equal(e.natureOfDistress, 'sinking');
+  assert.equal(e.distressedMmsi, '244223600');
+  assert.equal(e.mmsi, '002371100'); // relaying coast station
+});
+
+test('parseDsc: routine individual call carries a working channel, no position', () => {
+  const e = parseDsc(['20', '3669701230', '00', '06', '00', '000016', '', '', '', '', '']);
+  assert.equal(e.format, 'individual');
+  assert.equal(e.category, 'routine');
+  assert.equal(e.workingChannel, '16');
+  assert.equal(e.position, undefined);
+  assert.equal(e.expansion, false);
+});
+
+test('parseDsc: "position not available" yields no position', () => {
+  const e = parseDsc(['12', '2442236000', '12', '07', '00', '9999999999', '8888', '', '', '', '']);
+  assert.equal(e.position, undefined);
+  assert.equal(e.utcTime, undefined); // 8888 = time unavailable
+  assert.equal(e.natureOfDistress, 'undesignated');
+});
+
+test('parseDsc: malicious nature code cannot escape to a prototype key', () => {
+  const e = parseDsc(['12', '2442236000', '12', '__proto__', '00', '0484700327', '1423', '', '', '', '']);
+  assert.equal(e.natureOfDistress, 'undesignated');
+});
+
+test('parseDsc: impossible coordinates from a garbled packet are dropped', () => {
+  const e = parseDsc(['12', '2442236000', '12', '07', '00', '0997800000', '1423', '', '', '', '']);
+  assert.equal(e.position, undefined); // 99deg lat / 78min are not a position
+  assert.equal(e.category, 'distress'); // the rest of the call is still forwarded
+});
+
+test('parseDsc: first-party alert does not read field 7 as a casualty MMSI', () => {
+  const e = parseDsc(['12', '2442236000', '12', '02', '00', '0484700327', '1423', '3669701230', '', '', '']);
+  assert.equal(e.format, 'distressAlert');
+  assert.equal(e.relay, undefined);
+  assert.equal(e.distressedMmsi, undefined); // field 7 has no casualty meaning here
+});
+
+test('parseDse + refinePosition: enhances a minute-resolution position', () => {
+  const ext = parseDse(['1', '1', 'A', '2442236000', '00', '12345678']);
+  assert.equal(ext.mmsi, '244223600');
+  assert.ok(Math.abs(ext.latMinuteFraction - 0.1234) < 1e-9);
+  assert.ok(Math.abs(ext.lonMinuteFraction - 0.5678) < 1e-9);
+
+  const refined = refinePosition({ latitude: 48.7833333, longitude: 3.45 }, ext);
+  assert.ok(Math.abs(refined.latitude - (48.7833333 + 0.1234 / 60)) < 1e-6);
+  assert.ok(Math.abs(refined.longitude - (3.45 + 0.5678 / 60)) < 1e-6);
+});
+
+test('parseDse: multi-sentence groups are skipped', () => {
+  assert.equal(parseDse(['1', '2', 'A', '2442236000', '00', '12345678']), null);
+});
+
+test('refinePosition keeps a negative-zero coordinate in its hemisphere', () => {
+  // Position at 0deg00.0' W (prime meridian) parses as longitude -0; a DSE
+  // refinement to the west must stay negative, not flip to +E.
+  const refined = refinePosition(
+    { latitude: 50, longitude: -0 },
+    { latMinuteFraction: 0, lonMinuteFraction: 0.5 }
+  );
+  assert.ok(refined.longitude < 0, 'refined longitude should remain western');
+  assert.ok(Math.abs(refined.longitude - (-0.5 / 60)) < 1e-9);
+});
+
+test('normalizePgn129808: resolved lookup names', () => {
+  const e = normalizePgn129808({
+    pgn: 129808,
+    fields: {
+      dscFormat: 'Distress',
+      dscCategory: 'Distress',
+      dscMessageAddress: '244223600',
+      natureOfDistress: 'Sinking',
+      latitudeOfVesselReported: 48.7833,
+      longitudeOfVesselReported: 3.45,
+      timeOfPosition: '14:23:00',
+      mmsiOfShipInDistress: '244223600',
+    },
+  });
+  assert.equal(e.format, 'distressAlert');
+  assert.equal(e.category, 'distress');
+  assert.equal(e.mmsi, '244223600');
+  assert.equal(e.natureOfDistress, 'sinking');
+  assert.equal(e.relay, undefined);
+  assert.deepEqual(e.position, { latitude: 48.7833, longitude: 3.45 });
+  assert.equal(e.utcTime, '14:23');
+});
+
+test('normalizePgn129808: accepts canboat space-separated field names too', () => {
+  const e = normalizePgn129808({
+    pgn: 129808,
+    fields: {
+      'DSC Format': 'Distress',
+      'DSC Category': 'Distress',
+      'DSC Message Address': '244223600',
+      'Nature of Distress': 'Sinking',
+      'Latitude of Vessel Reported': 48.7833,
+      'Longitude of Vessel Reported': 3.45,
+      'Time of Position': '14:23:00',
+      'MMSI of Ship In Distress': '244223600',
+    },
+  });
+  assert.equal(e.format, 'distressAlert');
+  assert.equal(e.category, 'distress');
+  assert.equal(e.mmsi, '244223600');
+  assert.equal(e.natureOfDistress, 'sinking');
+  assert.deepEqual(e.position, { latitude: 48.7833, longitude: 3.45 });
+  assert.equal(e.utcTime, '14:23');
+  assert.equal(e.distressedMmsi, '244223600');
+});
+
+test('normalizePgn129808: drops an out-of-range position but keeps the rest', () => {
+  const e = normalizePgn129808({
+    pgn: 129808,
+    fields: {
+      'DSC Format': 'Distress',
+      'DSC Category': 'Distress',
+      'DSC Message Address': '244223600',
+      'Nature of Distress': 'Sinking',
+      'Latitude of Vessel Reported': 991.2, // impossible
+      'Longitude of Vessel Reported': 3.45,
+    },
+  });
+  assert.equal(e.position, undefined);
+  assert.equal(e.category, 'distress');
+  assert.equal(e.natureOfDistress, 'sinking');
+});
+
+test('normalizePgn129808: raw ITU symbol numbers and seconds-since-midnight time', () => {
+  const e = normalizePgn129808({
+    pgn: 129808,
+    fields: {
+      dscFormatSymbol: 112,
+      dscCategorySymbol: 112,
+      dscMessageAddress: '366970123',
+      '1stTelecommand': 1,
+      timeOfPosition: 51780, // 14:23:00
+    },
+  });
+  assert.equal(e.format, 'distressAlert');
+  assert.equal(e.category, 'distress');
+  assert.equal(e.natureOfDistress, 'flooding');
+  assert.equal(e.utcTime, '14:23');
+});


### PR DESCRIPTION
## Summary

Adds DSC (VHF Digital Selective Calling) support. The plugin now parses DSC calls from **NMEA 0183** (`$CDDSC`/`$CDDSE`) and **NMEA 2000** (PGN 129808) and forwards each one to Saillogger the moment it is received — so distress, urgency, and safety traffic in range is captured on demand rather than on the batch interval.

## Details

- **`lib/dsc.js`** — pure, transport-independent DSC parsers (adapted from the MIT-licensed [`signalk-dsc`](https://github.com/sailingnaturali/signalk-dsc), attribution retained). Handles distress/urgency/safety/routine calls, reported position (including `$CDDSE` position refinement), nature of distress, distress relays, AIS device beacons, and both camelCase and canonical canboat PGN field names.
- **`index.js`** — registers the two 0183 sentence parsers plus the N2K `N2KAnalyzerOut` listener, and POSTs each parsed call to the collector DSC endpoint immediately (event-driven, forward-only). Delivery is best-effort: `2xx` accepted, `3xx`/`4xx` dropped, `5xx`/network retried a few times in memory then dropped.
- **`test/dsc.test.js`** — zero-dependency `node --test` coverage for the parsers.
- Plugin version bumped to `5.2.0`; `npm test` now runs `node --test`.

## Testing

`npm test` — 14 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)